### PR TITLE
Change version.json to indicate we release out of master

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,1 +1,6 @@
-{ "version": "0.2" }
+{
+    "version": "0.2",
+    "publicReleaseRefSpec": [
+        "^refs/heads/master$" // we release out of master
+    ]
+}


### PR DESCRIPTION
This will prevent Nerdbank.GitVersioning from emitting a NuGet package that includes a build version.