### PR TITLE
Upgrade LibGit2Sharp

### DIFF
--- a/src/git-istage/git-istage.csproj
+++ b/src/git-istage/git-istage.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/git-istage/git-istage.csproj
+++ b/src/git-istage/git-istage.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.235" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/git-istage/git-istage.csproj
+++ b/src/git-istage/git-istage.csproj
@@ -15,18 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp">
-      <Version>0.25.3</Version>
-    </PackageReference>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries">
-      <Version>1.0.235</Version>
-    </PackageReference>
+    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.235" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>2.2.13</Version>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
From @ethomson:

> I've released a prerelease LibGit2Sharp that should help a bit here. I've
> updated libgit2 to have built-in support for proxies, so we no longer rely
> upon libcurl. I think this should help the native dependency problems quite
> a bit.

This should resolve the libcurl4 issue with have on Ubuntu 18.04.1. Fixes #13.