### PR TITLE
#27 - Supports custom key bindings.

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -90,3 +90,53 @@ Shortcut | Description
 <kbd>Ctrl</kbd> <kbd>→</kbd> | Scrolls right by one character,
 <kbd>Ctrl</kbd> <kbd>↑</kbd> | Scrolls up by one line.
 <kbd>Ctrl</kbd> <kbd>↓</kbd> | Scrolls down by one line.
+
+## Custom Key Bindings
+
+The [default key bindings](#keyboard-shortcuts) are set for a US QWERTY keyboard layout.
+
+The key bindings can be modified by creating a JSON file at the following location:
+
+- On Unix / MacOSX, `$HOME/.git-istage/key-bindings.json`
+- On Windows, `%HOMEDRIVE%%HOMEPATH%\.git-istage\key-bindings.json`
+
+The custom key bindings JSON file contains a JSON objects whose properties are the vailable [command names](/src/git-istage/key-bindings.json), and the their value is a JSON object containing a `KeyBindings` array specifying the new keyboard shortcuts.
+
+For instance, to use the <kbd>X</kbd> key to exit the program in addition of the default <kbd>Esc</kbd> or <kbd>Q</kbd> keys, use the following syntax:
+
+```
+{
+    "Exit": {
+        "keyBindings": ["X"]
+    }
+}
+```
+
+You can also completely override the default keyboard shortcuts. For instance, to exit the program _instead_ of the default <kbd>Esc</kbd> or <kbd>Q</kbd> keys, use the following syntax:
+
+```
+{
+    "Exit": {
+        "default": [],
+        "keyBindings": ["X"]
+    }
+}
+```
+
+Please, note that key binding strings are case insensitive. This means that, `X` and `Shift+x` represent two different key presses.
+
+For instance, on a recent [AZERTY-NF](https://springcomp.github.io/optimized-azerty-win/) keyboard layout, the <kbd>[</kbd> and <kbd>]</kbd> keys are located on the positions for the <kbd>5</kbd> and <kbd>6</kbd> keys, respectively. Since the default commands for these keys are <kbd>Oem4</kbd> and <kbd>Oem6</kbd>, I need to change the `GoNextHunk` and `GoPreviousHunk` key bindings like so:
+
+```
+{
+    "Exit": {
+        "keyBindings": ["X"]
+    },
+    "GoNextHunk": {
+        "keyBindings": ["AltGr+6"]
+    },
+    "GoPreviousHunk": {
+        "keyBindings": ["AltGr+5"]
+    }
+}
+```

--- a/src/git-istage.sln
+++ b/src/git-istage.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2041
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "git-istage", "git-istage\git-istage.csproj", "{58604E1E-7366-40E6-B69A-E0A9E3E2BBEE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "git-istage", "git-istage\git-istage.csproj", "{58604E1E-7366-40E6-B69A-E0A9E3E2BBEE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "git-istage.tests", "git-istage.tests\git-istage.tests.csproj", "{29028DFB-C516-459A-B189-7CB1F9B22480}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{58604E1E-7366-40E6-B69A-E0A9E3E2BBEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58604E1E-7366-40E6-B69A-E0A9E3E2BBEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58604E1E-7366-40E6-B69A-E0A9E3E2BBEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29028DFB-C516-459A-B189-7CB1F9B22480}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29028DFB-C516-459A-B189-7CB1F9B22480}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29028DFB-C516-459A-B189-7CB1F9B22480}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29028DFB-C516-459A-B189-7CB1F9B22480}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/git-istage.tests/KeyPressParserTests.cs
+++ b/src/git-istage.tests/KeyPressParserTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Xunit;
+
+namespace GitIStage.Tests
+{
+    public class KeyPressParserTests
+    {
+        [Fact]
+        public void KeyPressParser_ParseKey()
+        {
+            var parser = new KeyPressParser();
+            var result = parser.Parse("shift+ctrl+R");
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(ConsoleKey.R, result.Key);
+            Assert.Equal(ConsoleModifiers.Shift | ConsoleModifiers.Control, result.Modifiers);
+        }
+        [Fact]
+        public void KeyPressParser_ParseMinusKey()
+        {
+            var parser = new KeyPressParser();
+            var result = parser.Parse("-");
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(ConsoleKey.OemMinus, result.Key);
+        }
+        [Fact]
+        public void KeyPressParser_ParsePlusKey()
+        {
+            var parser = new KeyPressParser();
+            var result = parser.Parse("+");
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(ConsoleKey.OemPlus, result.Key);
+        }
+        [Fact]
+        public void KeyPressParser_ParseCtrlPlusKey()
+        {
+            var parser = new KeyPressParser();
+            var result = parser.Parse("ctrl++");
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(ConsoleKey.OemPlus, result.Key);
+            Assert.Equal(ConsoleModifiers.Control, result.Modifiers);
+        }
+    }
+}

--- a/src/git-istage.tests/git-istage.tests.csproj
+++ b/src/git-istage.tests/git-istage.tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>git_istage.tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\git-istage\git-istage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/git-istage/KeyBindings/KeyBinding.cs
+++ b/src/git-istage/KeyBindings/KeyBinding.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace GitIStage
+{
+    public class KeyBinding
+    {
+        [JsonProperty("default")]
+        public string[] Default { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+    public class CustomKeyBinding
+    {
+        [JsonProperty("before")]
+        public string Before { get; set; }
+        [JsonProperty("after")]
+        public string After { get; set; }
+    }
+
+}

--- a/src/git-istage/KeyBindings/KeyBinding.cs
+++ b/src/git-istage/KeyBindings/KeyBinding.cs
@@ -1,20 +1,25 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace GitIStage
 {
     public class KeyBinding
     {
         [JsonProperty("default")]
-        public string[] Default { get; set; }
+        public List<string> Default { get; set; }
         [JsonProperty("description")]
         public string Description { get; set; }
     }
     public class CustomKeyBinding
     {
-        [JsonProperty("before")]
-        public string Before { get; set; }
-        [JsonProperty("after")]
-        public string After { get; set; }
+        // set to an empty array (or null) to clear the default bindings
+        // for the corresponding command
+
+        [JsonProperty("default")]
+        public string[] Default { get; set; }
+
+        [JsonProperty("keyBindings")]
+        public string[] KeyBindings { get; set; }
     }
 
 }

--- a/src/git-istage/KeyBindings/KeyBindings.cs
+++ b/src/git-istage/KeyBindings/KeyBindings.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace GitIStage
 {
-    public class KeyBindings
+    public partial class KeyBindings
     {
         [JsonIgnore()]
         public IDictionary<string, KeyBinding> Handlers { get; set; }

--- a/src/git-istage/KeyBindings/KeyBindings.cs
+++ b/src/git-istage/KeyBindings/KeyBindings.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace GitIStage
+{
+    public class KeyBindings
+    {
+        [JsonIgnore()]
+        public IDictionary<string, KeyBinding> Handlers { get; set; }
+    }
+}

--- a/src/git-istage/KeyBindings/KeyBindingsHelper.cs
+++ b/src/git-istage/KeyBindings/KeyBindingsHelper.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json;
+
+namespace GitIStage
+{
+    public partial class KeyBindings
+    {
+        public static KeyBindings Load()
+        {
+            // load default key bindings from resource
+
+            KeyBindings keyBindings = null;
+
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("git-istage.key-bindings.json"))
+                keyBindings = LoadKeyBindings(stream);
+
+            // merge custom key bindings
+
+            var keyBindingsPath = ResolveCustomKeyBindingsPath();
+            if (!string.IsNullOrEmpty(keyBindingsPath) && File.Exists(keyBindingsPath))
+            {
+                var customKeyBindings = LoadCustomKeyBindings(keyBindingsPath);
+                foreach (var customKeyBinding in customKeyBindings)
+                {
+                    var command = customKeyBinding.Key;
+                    var key = customKeyBinding.Value.KeyBindings?.FirstOrDefault();
+                    if (key != null)
+                    {
+                        var binding = keyBindings.Handlers.SingleOrDefault(h => h.Key.ToLowerInvariant() == command.ToLowerInvariant()).Value;
+                        if (binding != null)
+                        {
+                            if (customKeyBinding.Value.Default?.Length == 0)
+                                binding.Default.Clear();
+                            binding.Default.Add(key);
+                        }
+                    }
+                }
+            }
+
+            return keyBindings;
+        }
+
+        private static IDictionary<string, CustomKeyBinding> LoadCustomKeyBindings(string keyBindingsPath)
+        {
+            using (var stream = File.Open(keyBindingsPath, FileMode.Open, FileAccess.Read))
+            using (var reader = new StreamReader(stream))
+            {
+                var content = reader.ReadToEnd();
+                return JsonConvert.DeserializeObject<Dictionary<string, CustomKeyBinding>>(content);
+            }
+        }
+
+        private static KeyBindings LoadKeyBindings(Stream stream)
+        {
+            var keyBindings = new KeyBindings();
+
+            using (var reader = new StreamReader(stream))
+            {
+                var content = reader.ReadToEnd();
+                keyBindings.Handlers = JsonConvert.DeserializeObject<Dictionary<string, KeyBinding>>(content);
+            }
+
+            return keyBindings;
+        }
+
+        private static string ResolveCustomKeyBindingsPath()
+        {
+            const string keyBindingsJsonFileName = ".git-istage/key-bindings.json";
+            var appDirectory = GetHomeDirectory();
+            return Path.Combine(appDirectory, keyBindingsJsonFileName);
+        }
+
+        private static string GetHomeDirectory()
+        {
+            string homePath =
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    ? Environment.GetEnvironmentVariable("HOME")
+                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%")
+                    ;
+
+            return homePath;
+        }
+    }
+}

--- a/src/git-istage/KeyBindings/KeyPressParser.cs
+++ b/src/git-istage/KeyBindings/KeyPressParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace GitIStage
 {
@@ -7,7 +8,7 @@ namespace GitIStage
     /// A simple parser for expressions referring to a keypress
     /// such as, "ctrl+q", "shift+a", etc.
     /// </summary>
-    internal class KeyPressParser
+    public class KeyPressParser
     {
         /// <summary>
         /// Returns a structure containing
@@ -19,7 +20,7 @@ namespace GitIStage
         /// <returns></returns>
         public Result Parse(string keyPress)
         {
-            var (modifiers, key, succeeded) = SplitLastOf(keyPress, "+");
+            var (modifiers, key, succeeded) = SplitLastOf(keyPress);
             if (succeeded)
             {
                 succeeded &= TryParseModifiers(modifiers, out var _mods);
@@ -224,7 +225,7 @@ namespace GitIStage
 
         private bool TryParseModifiersImpl(string modifiers, ref ConsoleModifiers mods)
         {
-            var (others, modifier, succeeded) = SplitLastOf(modifiers, "+");
+            var (others, modifier, succeeded) = SplitLastOf(modifiers);
             if (!succeeded)
                 return false;
 
@@ -262,22 +263,20 @@ namespace GitIStage
             return false;
         }
 
-        private (string, string, bool) SplitLastOf(string text, string c)
+        private (string, string, bool) SplitLastOf(string text)
         {
-            var second = text;
-            var first = "";
+            if (text.Length == 0)
+                return ("", text, true);
 
-            var pos = text.LastIndexOf("+");
-            if (pos != -1)
-            {
-                if (pos >= text.Length)
-                    return ("", "", false);
+            var pattern = @"(?:(?<first>.+)\+)?(?<second>.+)";
+            var regex = new Regex(pattern);
+            var match = regex.Match(text);
 
-                first = text.Substring(0, pos);
-                second = text.Substring(pos + 1);
-            }
-
-            return (first, second, true);
+            return (
+                match.Groups["first"].Value,
+                match.Groups["second"].Value,
+                match.Success
+                );
         }
     }
 }

--- a/src/git-istage/KeyBindings/KeyPressParser.cs
+++ b/src/git-istage/KeyBindings/KeyPressParser.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GitIStage
+{
+    /// <summary>
+    /// A simple parser for expressions referring to a keypress
+    /// such as, "ctrl+q", "shift+a", etc.
+    /// </summary>
+    internal class KeyPressParser
+    {
+        /// <summary>
+        /// Returns a structure containing
+        /// a status code and a combination of the
+        /// corresponding <see cref="ConsoleKey" />
+        /// and <see cref="ConsoleModifiers"/> values.
+        /// </summary>
+        /// <param name="keyPress"></param>
+        /// <returns></returns>
+        public Result Parse(string keyPress)
+        {
+            var (modifiers, key, succeeded) = SplitLastOf(keyPress, "+");
+            if (succeeded)
+            {
+                succeeded &= TryParseModifiers(modifiers, out var _mods);
+                succeeded &= TryParseKey(key, out var _key);
+
+                if (succeeded)
+                    return new Result
+                    {
+                        Succeeded = succeeded,
+                        Key = _key,
+                        Modifiers = _mods,
+                    };
+            }
+
+            return new Result();
+        }
+
+        public struct Result
+        {
+            public bool Succeeded { get; set; }
+            public ConsoleKey Key { get; set; }
+            public ConsoleModifiers Modifiers { get; set; }
+        }
+
+        private bool TryParseKey(string s, out ConsoleKey key)
+        {
+            key = 0;
+
+            if (IsKey(s, "F1")) { key = ConsoleKey.F1; return true; }
+            if (IsKey(s, "F2")) { key = ConsoleKey.F2; return true; }
+            if (IsKey(s, "F3")) { key = ConsoleKey.F3; return true; }
+            if (IsKey(s, "F4")) { key = ConsoleKey.F4; return true; }
+            if (IsKey(s, "F5")) { key = ConsoleKey.F5; return true; }
+            if (IsKey(s, "F6")) { key = ConsoleKey.F6; return true; }
+            if (IsKey(s, "F7")) { key = ConsoleKey.F7; return true; }
+            if (IsKey(s, "F8")) { key = ConsoleKey.F8; return true; }
+            if (IsKey(s, "F9")) { key = ConsoleKey.F9; return true; }
+            if (IsKey(s, "F10")) { key = ConsoleKey.F10; return true; }
+            if (IsKey(s, "F11")) { key = ConsoleKey.F11; return true; }
+            if (IsKey(s, "F12")) { key = ConsoleKey.F12; return true; }
+            if (IsKey(s, "F13")) { key = ConsoleKey.F13; return true; }
+            if (IsKey(s, "F14")) { key = ConsoleKey.F14; return true; }
+            if (IsKey(s, "F15")) { key = ConsoleKey.F15; return true; }
+            if (IsKey(s, "F16")) { key = ConsoleKey.F16; return true; }
+            if (IsKey(s, "F17")) { key = ConsoleKey.F17; return true; }
+            if (IsKey(s, "F18")) { key = ConsoleKey.F18; return true; }
+            if (IsKey(s, "F19")) { key = ConsoleKey.F19; return true; }
+            if (IsKey(s, "F20")) { key = ConsoleKey.F20; return true; }
+            if (IsKey(s, "F21")) { key = ConsoleKey.F21; return true; }
+            if (IsKey(s, "F22")) { key = ConsoleKey.F22; return true; }
+            if (IsKey(s, "F23")) { key = ConsoleKey.F23; return true; }
+            if (IsKey(s, "F24")) { key = ConsoleKey.F24; return true; }
+            if (IsKey(s, "D0")) { key = ConsoleKey.D0; return true; }
+            if (IsKey(s, "D1")) { key = ConsoleKey.D1; return true; }
+            if (IsKey(s, "D2")) { key = ConsoleKey.D2; return true; }
+            if (IsKey(s, "D3")) { key = ConsoleKey.D3; return true; }
+            if (IsKey(s, "D4")) { key = ConsoleKey.D4; return true; }
+            if (IsKey(s, "D5")) { key = ConsoleKey.D5; return true; }
+            if (IsKey(s, "D6")) { key = ConsoleKey.D6; return true; }
+            if (IsKey(s, "D7")) { key = ConsoleKey.D7; return true; }
+            if (IsKey(s, "D8")) { key = ConsoleKey.D8; return true; }
+            if (IsKey(s, "D9")) { key = ConsoleKey.D9; return true; }
+            if (IsKey(s, "0")) { key = ConsoleKey.D0; return true; }
+            if (IsKey(s, "1")) { key = ConsoleKey.D1; return true; }
+            if (IsKey(s, "2")) { key = ConsoleKey.D2; return true; }
+            if (IsKey(s, "3")) { key = ConsoleKey.D3; return true; }
+            if (IsKey(s, "4")) { key = ConsoleKey.D4; return true; }
+            if (IsKey(s, "5")) { key = ConsoleKey.D5; return true; }
+            if (IsKey(s, "6")) { key = ConsoleKey.D6; return true; }
+            if (IsKey(s, "7")) { key = ConsoleKey.D7; return true; }
+            if (IsKey(s, "8")) { key = ConsoleKey.D8; return true; }
+            if (IsKey(s, "9")) { key = ConsoleKey.D9; return true; }
+            if (IsKey(s, "A")) { key = ConsoleKey.A; return true; }
+            if (IsKey(s, "B")) { key = ConsoleKey.B; return true; }
+            if (IsKey(s, "C")) { key = ConsoleKey.C; return true; }
+            if (IsKey(s, "D")) { key = ConsoleKey.D; return true; }
+            if (IsKey(s, "E")) { key = ConsoleKey.E; return true; }
+            if (IsKey(s, "F")) { key = ConsoleKey.F; return true; }
+            if (IsKey(s, "G")) { key = ConsoleKey.G; return true; }
+            if (IsKey(s, "H")) { key = ConsoleKey.H; return true; }
+            if (IsKey(s, "P")) { key = ConsoleKey.P; return true; }
+            if (IsKey(s, "Q")) { key = ConsoleKey.Q; return true; }
+            if (IsKey(s, "R")) { key = ConsoleKey.R; return true; }
+            if (IsKey(s, "S")) { key = ConsoleKey.S; return true; }
+            if (IsKey(s, "T")) { key = ConsoleKey.T; return true; }
+            if (IsKey(s, "U")) { key = ConsoleKey.U; return true; }
+            if (IsKey(s, "V")) { key = ConsoleKey.V; return true; }
+            if (IsKey(s, "W")) { key = ConsoleKey.W; return true; }
+            if (IsKey(s, "X")) { key = ConsoleKey.X; return true; }
+            if (IsKey(s, "Y")) { key = ConsoleKey.Y; return true; }
+            if (IsKey(s, "Z")) { key = ConsoleKey.Z; return true; }
+            if (IsKey(s, "I")) { key = ConsoleKey.I; return true; }
+            if (IsKey(s, "J")) { key = ConsoleKey.J; return true; }
+            if (IsKey(s, "K")) { key = ConsoleKey.K; return true; }
+            if (IsKey(s, "L")) { key = ConsoleKey.L; return true; }
+            if (IsKey(s, "M")) { key = ConsoleKey.M; return true; }
+            if (IsKey(s, "N")) { key = ConsoleKey.N; return true; }
+            if (IsKey(s, "O")) { key = ConsoleKey.O; return true; }
+            if (IsKey(s, "Add")) { key = ConsoleKey.Add; return true; }
+            if (IsKey(s, "Applications")) { key = ConsoleKey.Applications; return true; }
+            if (IsKey(s, "Attention")) { key = ConsoleKey.Attention; return true; }
+            if (IsKey(s, "Backspace")) { key = ConsoleKey.Backspace; return true; }
+            if (IsKey(s, "BrowserBack")) { key = ConsoleKey.BrowserBack; return true; }
+            if (IsKey(s, "BrowserFavorites")) { key = ConsoleKey.BrowserFavorites; return true; }
+            if (IsKey(s, "BrowserForward")) { key = ConsoleKey.BrowserForward; return true; }
+            if (IsKey(s, "BrowserHome")) { key = ConsoleKey.BrowserHome; return true; }
+            if (IsKey(s, "BrowserRefresh")) { key = ConsoleKey.BrowserRefresh; return true; }
+            if (IsKey(s, "BrowserSearch")) { key = ConsoleKey.BrowserSearch; return true; }
+            if (IsKey(s, "BrowserStop")) { key = ConsoleKey.BrowserStop; return true; }
+            if (IsKey(s, "Clear")) { key = ConsoleKey.Clear; return true; }
+            if (IsKey(s, "CrSel")) { key = ConsoleKey.CrSel; return true; }
+            if (IsKey(s, "Decimal")) { key = ConsoleKey.Decimal; return true; }
+            if (IsKey(s, "Delete")) { key = ConsoleKey.Delete; return true; }
+            if (IsKey(s, "Divide")) { key = ConsoleKey.Divide; return true; }
+            if (IsKey(s, "DownArrow")) { key = ConsoleKey.DownArrow; return true; }
+            if (IsKey(s, "End")) { key = ConsoleKey.End; return true; }
+            if (IsKey(s, "Enter")) { key = ConsoleKey.Enter; return true; }
+            if (IsKey(s, "EraseEndOfFile")) { key = ConsoleKey.EraseEndOfFile; return true; }
+            if (IsKey(s, "Escape")) { key = ConsoleKey.Escape; return true; }
+            if (IsKey(s, "Esc")) { key = ConsoleKey.Escape; return true; }
+            if (IsKey(s, "Execute")) { key = ConsoleKey.Execute; return true; }
+            if (IsKey(s, "ExSel")) { key = ConsoleKey.ExSel; return true; }
+            if (IsKey(s, "Help")) { key = ConsoleKey.Help; return true; }
+            if (IsKey(s, "Home")) { key = ConsoleKey.Home; return true; }
+            if (IsKey(s, "Insert")) { key = ConsoleKey.Insert; return true; }
+            if (IsKey(s, "LaunchApp1")) { key = ConsoleKey.LaunchApp1; return true; }
+            if (IsKey(s, "LaunchApp2")) { key = ConsoleKey.LaunchApp2; return true; }
+            if (IsKey(s, "LaunchMail")) { key = ConsoleKey.LaunchMail; return true; }
+            if (IsKey(s, "LaunchMediaSelect")) { key = ConsoleKey.LaunchMediaSelect; return true; }
+            if (IsKey(s, "LeftArrow")) { key = ConsoleKey.LeftArrow; return true; }
+            if (IsKey(s, "LeftWindows")) { key = ConsoleKey.LeftWindows; return true; }
+            if (IsKey(s, "MediaNext")) { key = ConsoleKey.MediaNext; return true; }
+            if (IsKey(s, "MediaPlay")) { key = ConsoleKey.MediaPlay; return true; }
+            if (IsKey(s, "MediaPrevious")) { key = ConsoleKey.MediaPrevious; return true; }
+            if (IsKey(s, "MediaStop")) { key = ConsoleKey.MediaStop; return true; }
+            if (IsKey(s, "Multiply")) { key = ConsoleKey.Multiply; return true; }
+            if (IsKey(s, "NoName")) { key = ConsoleKey.NoName; return true; }
+            if (IsKey(s, "NumPad0")) { key = ConsoleKey.NumPad0; return true; }
+            if (IsKey(s, "NumPad1")) { key = ConsoleKey.NumPad1; return true; }
+            if (IsKey(s, "NumPad2")) { key = ConsoleKey.NumPad2; return true; }
+            if (IsKey(s, "NumPad3")) { key = ConsoleKey.NumPad3; return true; }
+            if (IsKey(s, "NumPad4")) { key = ConsoleKey.NumPad4; return true; }
+            if (IsKey(s, "NumPad5")) { key = ConsoleKey.NumPad5; return true; }
+            if (IsKey(s, "NumPad6")) { key = ConsoleKey.NumPad6; return true; }
+            if (IsKey(s, "NumPad7")) { key = ConsoleKey.NumPad7; return true; }
+            if (IsKey(s, "NumPad8")) { key = ConsoleKey.NumPad8; return true; }
+            if (IsKey(s, "NumPad9")) { key = ConsoleKey.NumPad9; return true; }
+            if (IsKey(s, "Oem1")) { key = ConsoleKey.Oem1; return true; }
+            if (IsKey(s, "Oem102")) { key = ConsoleKey.Oem102; return true; }
+            if (IsKey(s, "Oem2")) { key = ConsoleKey.Oem2; return true; }
+            if (IsKey(s, "Oem3")) { key = ConsoleKey.Oem3; return true; }
+            if (IsKey(s, "Oem4")) { key = ConsoleKey.Oem4; return true; }
+            if (IsKey(s, "Oem5")) { key = ConsoleKey.Oem5; return true; }
+            if (IsKey(s, "Oem6")) { key = ConsoleKey.Oem6; return true; }
+            if (IsKey(s, "Oem7")) { key = ConsoleKey.Oem7; return true; }
+            if (IsKey(s, "Oem8")) { key = ConsoleKey.Oem8; return true; }
+            if (IsKey(s, "OemClear")) { key = ConsoleKey.OemClear; return true; }
+            if (IsKey(s, "OemComma")) { key = ConsoleKey.OemComma; return true; }
+            if (IsKey(s, ",")) { key = ConsoleKey.OemComma; return true; }
+            if (IsKey(s, "OemMinus")) { key = ConsoleKey.OemMinus; return true; }
+            if (IsKey(s, "-")) { key = ConsoleKey.OemMinus; return true; }
+            if (IsKey(s, "OemPeriod")) { key = ConsoleKey.OemPeriod; return true; }
+            if (IsKey(s, ".")) { key = ConsoleKey.OemPeriod; return true; }
+            if (IsKey(s, "OemPlus")) { key = ConsoleKey.OemPlus; return true; }
+            if (IsKey(s, "+")) { key = ConsoleKey.OemPlus; return true; }
+            if (IsKey(s, "Pa1")) { key = ConsoleKey.Pa1; return true; }
+            if (IsKey(s, "Packet")) { key = ConsoleKey.Packet; return true; }
+            if (IsKey(s, "PageDown")) { key = ConsoleKey.PageDown; return true; }
+            if (IsKey(s, "PageUp")) { key = ConsoleKey.PageUp; return true; }
+            if (IsKey(s, "Pause")) { key = ConsoleKey.Pause; return true; }
+            if (IsKey(s, "Play")) { key = ConsoleKey.Play; return true; }
+            if (IsKey(s, "Print")) { key = ConsoleKey.Print; return true; }
+            if (IsKey(s, "PrintScreen")) { key = ConsoleKey.PrintScreen; return true; }
+            if (IsKey(s, "Process")) { key = ConsoleKey.Process; return true; }
+            if (IsKey(s, "RightArrow")) { key = ConsoleKey.RightArrow; return true; }
+            if (IsKey(s, "RightWindows")) { key = ConsoleKey.RightWindows; return true; }
+            if (IsKey(s, "Select")) { key = ConsoleKey.Select; return true; }
+            if (IsKey(s, "Separator")) { key = ConsoleKey.Separator; return true; }
+            if (IsKey(s, "Sleep")) { key = ConsoleKey.Sleep; return true; }
+            if (IsKey(s, "Spacebar")) { key = ConsoleKey.Spacebar; return true; }
+            if (IsKey(s, "Space")) { key = ConsoleKey.Spacebar; return true; }
+            if (IsKey(s, "Subtract")) { key = ConsoleKey.Subtract; return true; }
+            if (IsKey(s, "Tab")) { key = ConsoleKey.Tab; return true; }
+            if (IsKey(s, "UpArrow")) { key = ConsoleKey.UpArrow; return true; }
+            if (IsKey(s, "VolumeDown")) { key = ConsoleKey.VolumeDown; return true; }
+            if (IsKey(s, "VolumeMute")) { key = ConsoleKey.VolumeMute; return true; }
+            if (IsKey(s, "VolumeUp")) { key = ConsoleKey.VolumeUp; return true; }
+            if (IsKey(s, "Zoom")) { key = ConsoleKey.Zoom; return true; }
+            return false;
+        }
+
+        private bool IsKey(string c, string text)
+        {
+            return String.Compare(c, text, true) == 0;
+        }
+
+        private bool TryParseModifiers(string modifier, out ConsoleModifiers mods)
+        {
+            mods = 0;
+            return TryParseModifiersImpl(modifier, ref mods);
+        }
+
+        private bool TryParseModifiersImpl(string modifiers, ref ConsoleModifiers mods)
+        {
+            var (others, modifier, succeeded) = SplitLastOf(modifiers, "+");
+            if (!succeeded)
+                return false;
+
+            if (modifier.Length == 0)
+                return true;
+
+            if (!TryParseModifier(modifier, out var mod))
+                return false;
+
+            mods |= mod;
+
+            return TryParseModifiersImpl(others, ref mods);
+        }
+
+        private bool TryParseModifier(string modifier, out ConsoleModifiers mods)
+        {
+            mods = 0;
+
+            var mapping = new Dictionary<string, ConsoleModifiers>
+            {
+                ["altgr"] = ConsoleModifiers.Control | ConsoleModifiers.Alt,
+                ["alt"] = ConsoleModifiers.Alt,
+                ["shift"] = ConsoleModifiers.Shift,
+                ["ctrl"] = ConsoleModifiers.Control,
+                ["control"] = ConsoleModifiers.Control,
+            };
+
+            var mod = modifier.ToLowerInvariant();
+            if (mapping.ContainsKey(mod))
+            {
+                mods = mapping[mod];
+                return true;
+            }
+
+            return false;
+        }
+
+        private (string, string, bool) SplitLastOf(string text, string c)
+        {
+            var second = text;
+            var first = "";
+
+            var pos = text.LastIndexOf("+");
+            if (pos != -1)
+            {
+                if (pos >= text.Length)
+                    return ("", "", false);
+
+                first = text.Substring(0, pos);
+                second = text.Substring(pos + 1);
+            }
+
+            return (first, second, true);
+        }
+    }
+}

--- a/src/git-istage/Program.cs
+++ b/src/git-istage/Program.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using LibGit2Sharp;
-using Newtonsoft.Json;
 
 namespace GitIStage
 {
@@ -30,76 +26,10 @@ namespace GitIStage
                 return;
             }
 
-            var keyBindings = LoadKeyBindings();
+            var keyBindings = KeyBindings.Load();
 
             var application = new Application(repositoryPath, pathToGit, keyBindings);
             application.Run();
-        }
-
-        private static KeyBindings LoadKeyBindings()
-        {
-            // load default key bindings from resource
-
-            KeyBindings keyBindings = null;
-
-            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("git-istage.key-bindings.json"))
-                keyBindings = LoadKeyBindings(stream);
-
-            // merge custom key bindings
-
-            var keyBindingsPath = ResolveCustomKeyBindingsPath();
-            if (!string.IsNullOrEmpty(keyBindingsPath) && File.Exists(keyBindingsPath))
-            {
-                var customKeyBindings = LoadCustomKeyBindings(keyBindingsPath);
-                foreach (var customKeyBinding in customKeyBindings)
-                {
-                    var binding = keyBindings.Handlers.Values.SingleOrDefault(v => v.Default.Any(k => k.ToLowerInvariant() == customKeyBinding.Before.ToLowerInvariant()));
-                    binding.Default = ReplaceEntry(binding.Default, customKeyBinding.Before, customKeyBinding.After);
-                }
-            }
-
-            return keyBindings;
-        }
-
-        private static CustomKeyBinding[] LoadCustomKeyBindings(string keyBindingsPath)
-        {
-            using (var stream = File.Open(keyBindingsPath, FileMode.Open, FileAccess.Read))
-            using (var reader = new StreamReader(stream))
-            {
-                var content = reader.ReadToEnd();
-                return JsonConvert.DeserializeObject<CustomKeyBinding[]>(content);
-            }
-        }
-
-        private static KeyBindings LoadKeyBindings(Stream stream)
-        {
-            var keyBindings = new KeyBindings();
-
-            using (var reader = new StreamReader(stream))
-            {
-                var content = reader.ReadToEnd();
-                keyBindings.Handlers = JsonConvert.DeserializeObject<Dictionary<string, KeyBinding>>(content);
-            }
-
-            return keyBindings;
-        }
-
-        private static string ResolveCustomKeyBindingsPath()
-        {
-            const string keyBindingsJsonFileName = ".git-istage/key-bindings.json";
-            var appDirectory = GetHomeDirectory();
-            return Path.Combine(appDirectory, keyBindingsJsonFileName);
-        }
-
-        private static string GetHomeDirectory()
-        {
-            string homePath =
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    ? Environment.GetEnvironmentVariable("HOME")
-                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%")
-                    ;
-
-            return homePath;
         }
 
         private static string ResolveRepositoryPath()
@@ -134,21 +64,6 @@ namespace GitIStage
             var searchPaths = paths.SelectMany(p => fileNames.Select(f => Path.Combine(p, f)));
 
             return searchPaths.FirstOrDefault(File.Exists);
-        }
-
-        private static string[] ReplaceEntry(string[] array, string entry, string replacedBy)
-        {
-            var entries = new string[array.Length];
-
-            for (var index = 0; index < array.Length; index++)
-            {
-                entries[index] = string.Compare(array[index], entry, true) == 0
-                    ? replacedBy
-                    : array[index]
-                    ;
-            }
-
-            return entries;
         }
     }
 }

--- a/src/git-istage/Program.cs
+++ b/src/git-istage/Program.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using System.Reflection;
+using System.Runtime.InteropServices;
 using LibGit2Sharp;
+using Newtonsoft.Json;
 
 namespace GitIStage
 {
@@ -27,8 +30,76 @@ namespace GitIStage
                 return;
             }
 
-            var application = new Application(repositoryPath, pathToGit);
+            var keyBindings = LoadKeyBindings();
+
+            var application = new Application(repositoryPath, pathToGit, keyBindings);
             application.Run();
+        }
+
+        private static KeyBindings LoadKeyBindings()
+        {
+            // load default key bindings from resource
+
+            KeyBindings keyBindings = null;
+
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("git-istage.key-bindings.json"))
+                keyBindings = LoadKeyBindings(stream);
+
+            // merge custom key bindings
+
+            var keyBindingsPath = ResolveCustomKeyBindingsPath();
+            if (!string.IsNullOrEmpty(keyBindingsPath) && File.Exists(keyBindingsPath))
+            {
+                var customKeyBindings = LoadCustomKeyBindings(keyBindingsPath);
+                foreach (var customKeyBinding in customKeyBindings)
+                {
+                    var binding = keyBindings.Handlers.Values.SingleOrDefault(v => v.Default.Any(k => k.ToLowerInvariant() == customKeyBinding.Before.ToLowerInvariant()));
+                    binding.Default = ReplaceEntry(binding.Default, customKeyBinding.Before, customKeyBinding.After);
+                }
+            }
+
+            return keyBindings;
+        }
+
+        private static CustomKeyBinding[] LoadCustomKeyBindings(string keyBindingsPath)
+        {
+            using (var stream = File.Open(keyBindingsPath, FileMode.Open, FileAccess.Read))
+            using (var reader = new StreamReader(stream))
+            {
+                var content = reader.ReadToEnd();
+                return JsonConvert.DeserializeObject<CustomKeyBinding[]>(content);
+            }
+        }
+
+        private static KeyBindings LoadKeyBindings(Stream stream)
+        {
+            var keyBindings = new KeyBindings();
+
+            using (var reader = new StreamReader(stream))
+            {
+                var content = reader.ReadToEnd();
+                keyBindings.Handlers = JsonConvert.DeserializeObject<Dictionary<string, KeyBinding>>(content);
+            }
+
+            return keyBindings;
+        }
+
+        private static string ResolveCustomKeyBindingsPath()
+        {
+            const string keyBindingsJsonFileName = ".git-istage/key-bindings.json";
+            var appDirectory = GetHomeDirectory();
+            return Path.Combine(appDirectory, keyBindingsJsonFileName);
+        }
+
+        private static string GetHomeDirectory()
+        {
+            string homePath =
+                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    ? Environment.GetEnvironmentVariable("HOME")
+                    : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%")
+                    ;
+
+            return homePath;
         }
 
         private static string ResolveRepositoryPath()
@@ -63,6 +134,21 @@ namespace GitIStage
             var searchPaths = paths.SelectMany(p => fileNames.Select(f => Path.Combine(p, f)));
 
             return searchPaths.FirstOrDefault(File.Exists);
+        }
+
+        private static string[] ReplaceEntry(string[] array, string entry, string replacedBy)
+        {
+            var entries = new string[array.Length];
+
+            for (var index = 0; index < array.Length; index++)
+            {
+                entries[index] = string.Compare(array[index], entry, true) == 0
+                    ? replacedBy
+                    : array[index]
+                    ;
+            }
+
+            return entries;
         }
     }
 }

--- a/src/git-istage/git-istage.csproj
+++ b/src/git-istage/git-istage.csproj
@@ -15,8 +15,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <None Remove="key-bindings.json" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="key-bindings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -26,6 +33,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="custom-key-bindings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/git-istage/key-bindings.json
+++ b/src/git-istage/key-bindings.json
@@ -1,0 +1,170 @@
+{
+    "AppendLineDigit0": {
+        "default": [ "0" ],
+        "description": "Append digit 0 to line."
+    },
+    "AppendLineDigit1": {
+        "default": [ "1" ],
+        "description": "Append digit 1 to line."
+    },
+    "AppendLineDigit2": {
+        "default": [ "2" ],
+        "description": "Append digit 2 to line."
+    },
+    "AppendLineDigit3": {
+        "default": [ "3" ],
+        "description": "Append digit 3 to line."
+    },
+    "AppendLineDigit4": {
+        "default": [ "4" ],
+        "description": "Append digit 4 to line."
+    },
+    "AppendLineDigit5": {
+        "default": [ "5" ],
+        "description": "Append digit 5 to line."
+    },
+    "AppendLineDigit6": {
+        "default": [ "6" ],
+        "description": "Append digit 6 to line."
+    },
+    "AppendLineDigit7": {
+        "default": [ "7" ],
+        "description": "Append digit 7 to line."
+    },
+    "AppendLineDigit8": {
+        "default": [ "8" ],
+        "description": "Append digit 8 to line."
+    },
+    "AppendLineDigit9": {
+        "default": [ "9" ],
+        "description": "Append digit 9 to line."
+    },
+    "Commit": {
+        "default": [ "C" ],
+        "description": "Author commit"
+    },
+    "DecreaseContext": {
+        "default": [ "OemMinus" ],
+        "description": "Decreases the number of contextual lines."
+    },
+    "Exit": {
+        "default": [ "Esc", "Q" ],
+        "description": "Return to command line."
+    },
+    "GoEnd": {
+        "default": [ "End" ],
+        "description": "Selects the last line."
+    },
+    "GoEndOrInputLine": {
+        "default": [ "Shift+G" ],
+        "description": "Selects the last line (or Line N)."
+    },
+    "GoHome": {
+        "default": [ "Home" ],
+        "description": "Selects the first line."
+    },
+    "GoHomeOrInputLine": {
+        "default": [ "G" ],
+        "description": "Selects the first line (or Line N)."
+    },
+    "GoNextFile": {
+        "default": [ "RightArrow" ],
+        "description": "Go to the next file."
+    },
+    "GoNextHunk": {
+        "default": [ "Oem6" ],
+        "description": "Go to next change block."
+    },
+    "GoPreviousFile": {
+        "default": [ "LeftArrow" ],
+        "description": "Go to the previous file."
+    },
+    "GoPreviousHunk": {
+        "default": [ "Oem4" ],
+        "description": "Go to previous change block."
+    },
+    "IncreaseContext": {
+        "default": [ "OemPlus" ],
+        "description": "Increases the number of contextual lines."
+    },
+    "RemoveLastLineDigit": {
+        "default": [ "BackSpace" ],
+        "description": "Remove last line digit"
+    },
+    "Reset": {
+        "default": [ "R" ],
+        "description": "When viewing the working copy, removes the selected line from the working copy."
+    },
+    "ResetHunk": {
+        "default": [ "Shift+R" ],
+        "description": "When viewing the working copy, removes the selected block from the working copy."
+    },
+    "ScrollDown": {
+        "default": [ "Control+DownArrow" ],
+        "description": "Scrolls down by one line."
+    },
+    "ScrollLeft": {
+        "default": [ "Control+LeftArrow" ],
+        "description": "Scrolls left by one character."
+    },
+    "ScrollPageDown": {
+        "default": [ "PageDown", "SpaceBar" ],
+        "description": "Selects the line one screen below."
+    },
+    "ScrollPageUp": {
+        "default": [ "PageUp" ],
+        "description": "Selects the line one screen above."
+    },
+    "ScrollRight": {
+        "default": [ "Control+RightArrow" ],
+        "description": "Scrolls right by one character."
+    },
+    "ScrollUp": {
+        "default": [ "Control+UpArrow" ],
+        "description": "Scrolls up by one line."
+    },
+    "SelectDown": {
+        "default": [ "DownArrow", "J" ],
+        "description": "Selects the next line."
+    },
+    "SelectUp": {
+        "default": [ "UpArrow", "K" ],
+        "description": "Selects the previous line."
+    },
+    "ShowHelpPage": {
+        "default": [ "F1", "Shift+Oem2" ],
+        "description": "Show / hide help page."
+    },
+    "Stage": {
+        "default": [ "S" ],
+        "description": "When viewing the working copy, stages the selected line."
+    },
+    "StageHunk": {
+        "default": [ "Shift+S" ],
+        "description": "When viewing the working copy, stages the selected block."
+    },
+    "Stash": {
+        "default": [ "Alt+S" ],
+        "description": "Stashes changes from the working copy, but leaves the stage as-is."
+    },
+    "ToggleBetweenWorkingDirectoryAndStaging": {
+        "default": [ "T" ],
+        "description": "Toggle between working copy changes and staged changes."
+    },
+    "ToggleWhitespace": {
+        "default": [ "W" ],
+        "description": "Toggles between showing and hiding whitespace."
+    },
+    "ToogleFullDiff": {
+        "default": [ "Oem7" ],
+        "description": "Toggles between standard diff and full diff"
+    },
+    "Unstage": {
+        "default": [ "U" ],
+        "description": "When viewing the stage, unstages the selected line."
+    },
+    "UnstageHunk": {
+        "default": [ "Shift+U" ],
+        "description": "When viewing the stage, unstages the selected block."
+    }
+}


### PR DESCRIPTION
The [default key bindings](https://github.com/terrajobst/git-istage/blob/main/docs/about.md#keyboard-shortcuts) are set for a US QWERTY keyboard layout.

The key bindings can be modified by creating a JSON file at the following location:

- On Unix / MacOSX, `$HOME/.git-istage/key-bindings.json`
- On Windows, `%HOMEDRIVE%%HOMEPATH%\.git-istage\key-bindings.json`

The custom key bindings JSON file contains a JSON object whose properties are the available [command names](/src/git-istage/key-bindings.json), and the their value is a JSON object containing a `KeyBindings` array specifying the new keyboard shortcuts.

For instance, to use the <kbd>X</kbd> key to exit the program in addition of the default <kbd>Esc</kbd> and <kbd>Q</kbd> keys, use the following syntax:

```
{
    "Exit": {
        "keyBindings": ["X"]
    }
}
```

You can also completely override the default keyboard shortcuts. For instance, to exit the program using the <kbd>X</kbd> key _instead_ of the default <kbd>Esc</kbd> or <kbd>Q</kbd> key, use the following syntax:

```
{
    "Exit": {
        "default": [],
        "keyBindings": ["X"]
    }
}
```

Please, note that key binding strings are case insensitive. This means that, `X` and `Shift+x` represent two different key presses.

For instance, on a recent [AZERTY-NF](https://springcomp.github.io/optimized-azerty-win/) keyboard layout, the <kbd>[</kbd> and <kbd>]</kbd> keys are located on the positions for the <kbd>5</kbd> and <kbd>6</kbd> keys, respectively. Since the default commands for these keys are mapped to <kbd>Oem4</kbd> and <kbd>Oem6</kbd>, I need to change the `GoNextHunk` and `GoPreviousHunk` key bindings like so:

```
{
    "Exit": {
        "keyBindings": ["X"]
    },
    "GoNextHunk": {
        "default": [],
        "keyBindings": ["AltGr+6"]
    },
    "GoPreviousHunk": {
        "default": [],
        "keyBindings": ["AltGr+5"]
    }
}
```