### PR TITLE
Fix typo `Toogle` in Application.cs and default `key-bindings.json` file

### DIFF
--- a/src/git-istage/Application.cs
+++ b/src/git-istage/Application.cs
@@ -281,7 +281,7 @@ namespace GitIStage
             UpdateRepository();
         }
 
-        private void ToogleFullDiff()
+        private void ToggleFullDiff()
         {
             if (_helpShowing) return;
             _fullFileDiff = !_fullFileDiff;

--- a/src/git-istage/key-bindings.json
+++ b/src/git-istage/key-bindings.json
@@ -155,7 +155,7 @@
         "default": [ "W" ],
         "description": "Toggles between showing and hiding whitespace."
     },
-    "ToogleFullDiff": {
+    "ToggleFullDiff": {
         "default": [ "Oem7" ],
         "description": "Toggles between standard diff and full diff"
     },


### PR DESCRIPTION
As the title states this PR fixes a spelling mistake.