### PR TITLE
Fix instances where we try to write a negative count of whitespace

### DIFF
--- a/src/git-istage/Label.cs
+++ b/src/git-istage/Label.cs
@@ -64,7 +64,7 @@ namespace GitIStage
             Console.SetCursorPosition(_left, _top);
             Console.Write(text);
 
-            var remaining = _width - Text.Length;
+            var remaining = _width - textLength;
             Console.Write(_whitespace, 0, remaining);
 
             Console.ForegroundColor = oldForeground;


### PR DESCRIPTION
Fixes #38. It turns out we were using the wrong textLength to calculate how many spaces to print.