### PR TITLE
Improve file navigation

### DIFF
--- a/src/git-istage.tests/Infrastructure/RepositoryTests.cs
+++ b/src/git-istage.tests/Infrastructure/RepositoryTests.cs
@@ -213,7 +213,7 @@ public abstract class RepositoryTests : IDisposable
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var actualChangeLines = new List<string>();
-        for (var i = 0; i < document.Height - 1; i++)
+        for (var i = 0; i < document.Height; i++)
         {
             var line = document.GetLine(i);
             var colon = line.IndexOf(':');

--- a/src/git-istage/Patches/PatchDocument.cs
+++ b/src/git-istage/Patches/PatchDocument.cs
@@ -20,9 +20,16 @@ internal sealed class PatchDocument : Document
 
     public override int Width { get; }
 
+    public override int EntryCount => Entries.Count;
+
     public override string GetLine(int index)
     {
         return Lines[index].Text;
+    }
+
+    public override int GetLineIndex(int index)
+    {
+        return Entries[index].Offset;
     }
 
     public PatchEntry? FindEntry(int lineIndex)
@@ -31,7 +38,7 @@ internal sealed class PatchDocument : Document
         return index < 0 ? null : Entries[index];
     }
 
-    public int FindEntryIndex(int lineIndex)
+    public override int FindEntryIndex(int lineIndex)
     {
         // TODO: binary search would be more appropriate
 

--- a/src/git-istage/Patches/PatchExtension.cs
+++ b/src/git-istage/Patches/PatchExtension.cs
@@ -8,18 +8,6 @@ internal static class PatchExtension
                        PatchLineKind.Removal;
     }
 
-    public static int FindPreviousEntryIndex(this PatchDocument document, int lineIndex)
-    {
-        var entryIndex = document.FindEntryIndex(lineIndex);
-        return Math.Max(entryIndex - 1, 0);
-    }
-
-    public static int FindNextEntryIndex(this PatchDocument document, int lineIndex)
-    {
-        var entryIndex = document.FindEntryIndex(lineIndex);
-        return Math.Min(entryIndex + 1, document.Entries.Count - 1);
-    }
-
     public static int FindPreviousChangeBlock(this PatchDocument document, int lineIndex)
     {
         var start = lineIndex;

--- a/src/git-istage/Patches/PatchExtension.cs
+++ b/src/git-istage/Patches/PatchExtension.cs
@@ -13,15 +13,15 @@ internal static class PatchExtension
         var start = lineIndex;
 
         // Skip current block
-        while (start > 0 && document.Lines[start].Kind.IsAdditionOrRemoval())
+        while (start >= 0 && document.Lines[start].Kind.IsAdditionOrRemoval())
             start--;
 
         // Find next block
-        while (start > 0 && !document.Lines[start].Kind.IsAdditionOrRemoval())
+        while (start >= 0 && !document.Lines[start].Kind.IsAdditionOrRemoval())
             start--;
 
-        if (start < 0 || !document.Lines[start].Kind.IsAdditionOrRemoval())
-            return lineIndex;
+        if (start < 0)
+            return FindStartOfChangeBlock(document, lineIndex);
 
         return start;
     }
@@ -31,15 +31,15 @@ internal static class PatchExtension
         var end = lineIndex;
 
         // Skip current block
-        while (end < document.Lines.Count - 1 && document.Lines[end].Kind.IsAdditionOrRemoval())
+        while (end < document.Lines.Count && document.Lines[end].Kind.IsAdditionOrRemoval())
             end++;
 
         // Find next block
-        while (end < document.Lines.Count - 1 && !document.Lines[end].Kind.IsAdditionOrRemoval())
+        while (end < document.Lines.Count && !document.Lines[end].Kind.IsAdditionOrRemoval())
             end++;
 
-        if (end >= document.Lines.Count || !document.Lines[end].Kind.IsAdditionOrRemoval())
-            return lineIndex;
+        if (end >= document.Lines.Count)
+            return FindEndOfChangeBlock(document, lineIndex);
 
         return end;
     }

--- a/src/git-istage/Services/CommandService.cs
+++ b/src/git-istage/Services/CommandService.cs
@@ -315,19 +315,8 @@ internal sealed class CommandService
             return;
 
         var document = (Document)_documentService.Document;
-        var currentIndex = document.FindEntryIndex(i);
-        var lineIndex = document.GetLineIndex(currentIndex);
-
-        if (_uiService.View.SelectedLine > lineIndex)
-        {
-            _uiService.View.SelectedLine = lineIndex;
-        }
-        else
-        {
-            var nextIndex = document.FindPreviousEntryIndex(i);
-            _uiService.View.SelectedLine = document.GetLineIndex(nextIndex);
-        }
-
+        var nextIndex = document.FindPreviousEntryIndex(i);
+        _uiService.View.SelectedLine = document.GetLineIndex(nextIndex);
         _uiService.View.BringIntoView(_uiService.View.SelectedLine);
     }
 
@@ -341,12 +330,11 @@ internal sealed class CommandService
 
         var document = (Document)_documentService.Document;
         var nextIndex = document.FindNextEntryIndex(i);
-        var lineIndex = document.GetLineIndex(nextIndex);
 
-        if (_uiService.View.SelectedLine < lineIndex)
-            _uiService.View.SelectedLine = lineIndex;
+        if (nextIndex < document.EntryCount)
+            _uiService.View.SelectedLine = document.GetLineIndex(nextIndex);
         else
-            _uiService.View.SelectedLine = document.Height - 1;
+            _uiService.View.SelectedLine = _uiService.View.DocumentHeight - 1;
 
         _uiService.View.BringIntoView(_uiService.View.SelectedLine);
     }

--- a/src/git-istage/Services/CommandService.cs
+++ b/src/git-istage/Services/CommandService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using GitIStage.Commands;
 using GitIStage.Patches;
+using GitIStage.UI;
 using LibGit2Sharp;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -313,9 +314,20 @@ internal sealed class CommandService
         if (i < 0)
             return;
 
-        var document = (PatchDocument)_documentService.Document;
-        var nextIndex = document.FindPreviousEntryIndex(i);
-        _uiService.View.SelectedLine = document.Entries[nextIndex].Offset;
+        var document = (Document)_documentService.Document;
+        var currentIndex = document.FindEntryIndex(i);
+        var lineIndex = document.GetLineIndex(currentIndex);
+
+        if (_uiService.View.SelectedLine > lineIndex)
+        {
+            _uiService.View.SelectedLine = lineIndex;
+        }
+        else
+        {
+            var nextIndex = document.FindPreviousEntryIndex(i);
+            _uiService.View.SelectedLine = document.GetLineIndex(nextIndex);
+        }
+
         _uiService.View.BringIntoView(_uiService.View.SelectedLine);
     }
 
@@ -327,9 +339,15 @@ internal sealed class CommandService
         if (i < 0)
             return;
 
-        var document = (PatchDocument)_documentService.Document;
+        var document = (Document)_documentService.Document;
         var nextIndex = document.FindNextEntryIndex(i);
-        _uiService.View.SelectedLine = document.Entries[nextIndex].Offset;
+        var lineIndex = document.GetLineIndex(nextIndex);
+
+        if (_uiService.View.SelectedLine < lineIndex)
+            _uiService.View.SelectedLine = lineIndex;
+        else
+            _uiService.View.SelectedLine = document.Height - 1;
+
         _uiService.View.BringIntoView(_uiService.View.SelectedLine);
     }
 

--- a/src/git-istage/Services/CommandService.cs
+++ b/src/git-istage/Services/CommandService.cs
@@ -274,18 +274,19 @@ internal sealed class CommandService
     [CommandHandler("Selects the line one screen above.", "PageUp")]
     private void ScrollPageUp()
     {
-        _uiService.View.TopLine = Math.Max(0, _uiService.View.TopLine - _uiService.View.Height);
-        _uiService.View.SelectedLine = _uiService.View.TopLine;
+        var delta = Math.Min(_uiService.View.Height, _uiService.View.SelectedLine);
+        _uiService.View.TopLine = Math.Max(0, _uiService.View.TopLine - delta);
+        _uiService.View.SelectedLine = _uiService.View.SelectedLine - delta;
     }
 
     [CommandHandler("Selects the line one screen below.", "PageDown", "SpaceBar")]
     private void ScrollPageDown()
     {
+        var delta = Math.Min(_uiService.View.Height, _uiService.View.DocumentHeight - _uiService.View.SelectedLine - 1);
         _uiService.View.TopLine = Math.Min(
             Math.Max(0, _uiService.View.DocumentHeight - _uiService.View.Height),
-            _uiService.View.TopLine + _uiService.View.Height);
-
-        _uiService.View.SelectedLine = _uiService.View.TopLine;
+            _uiService.View.TopLine + delta);
+        _uiService.View.SelectedLine = _uiService.View.SelectedLine + delta;
     }
 
     [CommandHandler("Scrolls left by one character.", "Control+LeftArrow")]

--- a/src/git-istage/Services/CommandService.cs
+++ b/src/git-istage/Services/CommandService.cs
@@ -343,7 +343,7 @@ internal sealed class CommandService
     [CommandHandler("Go to previous change block.", "Oem4")]
     private void GoPreviousHunk()
     {
-        if (_uiService.HelpShowing) return;
+        if (_uiService.HelpShowing || _documentService.ViewFiles) return;
         var i = _uiService.View.SelectedLine;
         if (i < 0)
             return;
@@ -356,7 +356,7 @@ internal sealed class CommandService
     [CommandHandler("Go to next change block.", "Oem6")]
     private void GoNextHunk()
     {
-        if (_uiService.HelpShowing) return;
+        if (_uiService.HelpShowing || _documentService.ViewFiles) return;
         var i = _uiService.View.SelectedLine;
         if (i < 0)
             return;

--- a/src/git-istage/Services/CommandService.cs
+++ b/src/git-istage/Services/CommandService.cs
@@ -314,7 +314,7 @@ internal sealed class CommandService
         if (i < 0)
             return;
 
-        var document = (Document)_documentService.Document;
+        var document = _documentService.Document;
         var nextIndex = document.FindPreviousEntryIndex(i);
         _uiService.View.SelectedLine = document.GetLineIndex(nextIndex);
         _uiService.View.BringIntoView(_uiService.View.SelectedLine);
@@ -328,7 +328,7 @@ internal sealed class CommandService
         if (i < 0)
             return;
 
-        var document = (Document)_documentService.Document;
+        var document = _documentService.Document;
         var nextIndex = document.FindNextEntryIndex(i);
 
         if (nextIndex < document.EntryCount)

--- a/src/git-istage/Services/UIService.cs
+++ b/src/git-istage/Services/UIService.cs
@@ -164,8 +164,8 @@ internal sealed class UIService
             Vt100.SetForegroundColor(ConsoleColor.Blue);
             Vt100.SetBackgroundColor(ConsoleColor.Gray);
             Console.Write("/");
-            Vt100.EraseRestOfCurrentLine();
             Console.Write(sb);
+            Vt100.EraseRestOfCurrentLine();
             Vt100.ShowCursor();
 
             var k = Console.ReadKey(intercept: true);
@@ -205,8 +205,8 @@ internal sealed class UIService
             Vt100.SetCursorPosition(0, Console.WindowHeight - 1);
             Vt100.SetForegroundColor(ConsoleColor.Blue);
             Vt100.SetBackgroundColor(ConsoleColor.Gray);
-            Vt100.EraseRestOfCurrentLine();
             Console.Write("<< NO RESULTS FOUND >>");
+            Vt100.EraseRestOfCurrentLine();
             Console.ReadKey();
             UpdateFooter();
             return;

--- a/src/git-istage/UI/Document.cs
+++ b/src/git-istage/UI/Document.cs
@@ -6,17 +6,31 @@ internal abstract class Document
 
     public abstract int Height { get; }
     public abstract int Width { get; }
+    public abstract int EntryCount { get; }
 
     public abstract string GetLine(int index);
+    public abstract int GetLineIndex(int index);
+    public abstract int FindEntryIndex(int lineIndex);
 
     private sealed class EmptyDocument : Document
     {
         public override int Height => 0;
         public override int Width => 0;
+        public override int EntryCount => 0;
 
         public override string GetLine(int index)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        public override int GetLineIndex(int index)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        public override int FindEntryIndex(int lineIndex)
+        {
+            throw new ArgumentOutOfRangeException(nameof(lineIndex));
         }
     }
 }

--- a/src/git-istage/UI/DocumentExtensions.cs
+++ b/src/git-istage/UI/DocumentExtensions.cs
@@ -5,12 +5,16 @@ internal static class DocumentExtensions
     public static int FindPreviousEntryIndex(this Document document, int lineIndex)
     {
         var entryIndex = document.FindEntryIndex(lineIndex);
-        return Math.Max(entryIndex - 1, 0);
+        var index = document.GetLineIndex(entryIndex);
+        if (index < lineIndex)
+            return entryIndex;
+        else
+            return Math.Max(entryIndex - 1, 0);
     }
 
     public static int FindNextEntryIndex(this Document document, int lineIndex)
     {
         var entryIndex = document.FindEntryIndex(lineIndex);
-        return Math.Min(entryIndex + 1, document.EntryCount - 1);
+        return Math.Min(entryIndex + 1, document.EntryCount);
     }
 }

--- a/src/git-istage/UI/DocumentExtensions.cs
+++ b/src/git-istage/UI/DocumentExtensions.cs
@@ -1,0 +1,16 @@
+namespace GitIStage.UI;
+
+internal static class DocumentExtensions
+{
+    public static int FindPreviousEntryIndex(this Document document, int lineIndex)
+    {
+        var entryIndex = document.FindEntryIndex(lineIndex);
+        return Math.Max(entryIndex - 1, 0);
+    }
+
+    public static int FindNextEntryIndex(this Document document, int lineIndex)
+    {
+        var entryIndex = document.FindEntryIndex(lineIndex);
+        return Math.Min(entryIndex + 1, document.EntryCount - 1);
+    }
+}

--- a/src/git-istage/UI/FileDocument.cs
+++ b/src/git-istage/UI/FileDocument.cs
@@ -21,11 +21,24 @@ internal sealed class FileDocument : Document
 
     public override int Width { get; }
 
+    public override int EntryCount => _changes.Count;
+
     public IReadOnlyList<TreeEntryChanges> Changes => _changes;
 
     public override string GetLine(int index)
     {
         return _lines[index];
+    }
+
+    public override int GetLineIndex(int index)
+    {
+        return _indexOfFirstFile + index;
+    }
+
+    public override int FindEntryIndex(int lineIndex)
+    {
+        var changeIndex = lineIndex - _indexOfFirstFile;
+        return Math.Min(Math.Max(changeIndex, -1), _changes.Count - 1);
     }
 
     public TreeEntryChanges? GetChange(int index)
@@ -44,7 +57,6 @@ internal sealed class FileDocument : Document
         {
             builder.AppendLine();
             builder.AppendLine(viewStage ? "Changes to be committed:" : "Changes not staged for commit:");
-            builder.AppendLine();
 
             var indent = new string(' ', 8);
 
@@ -53,10 +65,10 @@ internal sealed class FileDocument : Document
                 var path = c.Path;
                 var change = (c.Status.ToString().ToLower() + ":").PadRight(12);
 
+                builder.AppendLine();
                 builder.Append(indent);
                 builder.Append(change);
                 builder.Append(path);
-                builder.AppendLine();
             }
         }
 

--- a/src/git-istage/UI/HelpDocument.cs
+++ b/src/git-istage/UI/HelpDocument.cs
@@ -48,8 +48,20 @@ internal sealed class HelpDocument : Document
 
     public override int Width { get; }
 
+    public override int EntryCount => _lines.Length;
+
     public override string GetLine(int index)
     {
         return _lines[index];
+    }
+
+    public override int GetLineIndex(int index)
+    {
+        return index;
+    }
+
+    public override int FindEntryIndex(int lineIndex)
+    {
+        return lineIndex;
     }
 }

--- a/src/git-istage/UI/Label.cs
+++ b/src/git-istage/UI/Label.cs
@@ -55,7 +55,7 @@ internal sealed class Label
         Vt100.SetCursorPosition(_left, _top);
         Vt100.SetForegroundColor(_foreground);
         Vt100.SetBackgroundColor(_background);
-        Vt100.EraseRestOfCurrentLine();
         Console.Write(text);
+        Vt100.EraseRestOfCurrentLine();
     }
 }

--- a/src/git-istage/UI/View.cs
+++ b/src/git-istage/UI/View.cs
@@ -209,6 +209,7 @@ internal sealed class View
             {
                 // We need to scroll up by -delta lines.
 
+                Vt100.SetBackgroundColor(ConsoleColor.Black);
                 Vt100.ScrollDown(Math.Abs(delta));
 
                 for (var i = 0; i < -delta; i++)
@@ -223,6 +224,7 @@ internal sealed class View
 
                 var visualLineCount = Height - delta;
 
+                Vt100.SetBackgroundColor(ConsoleColor.Black);
                 Vt100.ScrollUp(delta);
 
                 for (var i = 0; i < delta; i++)

--- a/src/git-istage/UI/ViewLineRenderer.cs
+++ b/src/git-istage/UI/ViewLineRenderer.cs
@@ -24,8 +24,8 @@ internal class ViewLineRenderer
         Vt100.SetCursorPosition(view.Left, visualLine);
         Vt100.SetForegroundColor(foregroundColor);
         Vt100.SetBackgroundColor(backgroundColor);
-        Vt100.EraseRestOfCurrentLine();
         Console.Write(text);
+        Vt100.EraseRestOfCurrentLine();
 
         if (view.SearchResults is not null)
         {


### PR DESCRIPTION
I got used to left/right arrows to navigate between files so extending that to the files view (which also fixes a crash as those commands assumed a PatchDocument).

Also tweaking the file navigation a bit to make behavior a bit more consistent between the first and last files:
1. If you are in the middle of a file then left arrow brings you to the start of that file: for long files found not having the ability to jump to the top of the file a bit limiting (could navigate to the previous then forward again, but then it was different for the first file)
2. If you are in the last file then right arrow brings you to the last line of the document: found it very frustrating not being able to jump to the last line of the file.
3. Change page up/down behavior by maintaining line position where possible and allowing the last line to be selected.
4. Change hunk navigation behavior by selecting the start or end of the hunk if navigation has reached the first or last hunk, respectively.