### PR TITLE
Support foreground and background colors that differ from the color palette

### DIFF
--- a/src/git-istage/Patches/PatchDocumentLineRenderer.cs
+++ b/src/git-istage/Patches/PatchDocumentLineRenderer.cs
@@ -12,11 +12,11 @@ internal sealed class PatchDocumentLineRenderer : ViewLineRenderer
         return document?.Lines[lineIndex];
     }
 
-    private static ConsoleColor GetForegroundColor(View view, int lineIndex)
+    private static ConsoleColor? GetForegroundColor(View view, int lineIndex)
     {
         var line = GetLine(view, lineIndex);
         if (line is null)
-            return ConsoleColor.Gray;
+            return null;
 
         switch (line.Kind)
         {
@@ -33,15 +33,15 @@ internal sealed class PatchDocumentLineRenderer : ViewLineRenderer
             case PatchLineKind.Removal:
                 return ConsoleColor.DarkRed;
             default:
-                return ConsoleColor.Gray;
+                return null;
         }
     }
 
-    private static ConsoleColor GetBackgroundColor(View view, int lineIndex)
+    private static ConsoleColor? GetBackgroundColor(View view, int lineIndex)
     {
         var patchLine = GetLine(view, lineIndex);
         if (patchLine is null)
-            return ConsoleColor.Black;
+            return null;
 
         var kind = patchLine.Kind;
 
@@ -53,7 +53,7 @@ internal sealed class PatchDocumentLineRenderer : ViewLineRenderer
                 : ConsoleColor.DarkGray;
         }
 
-        return kind == PatchLineKind.DiffLine ? ConsoleColor.DarkBlue : ConsoleColor.Black;
+        return kind == PatchLineKind.DiffLine ? ConsoleColor.DarkBlue : null;
     }
 
     public override void Render(View view, int lineIndex)

--- a/src/git-istage/UI/FileDocumentLineRenderer.cs
+++ b/src/git-istage/UI/FileDocumentLineRenderer.cs
@@ -12,11 +12,11 @@ internal sealed class FileDocumentLineRenderer : ViewLineRenderer
         return document?.GetChange(lineIndex);
     }
 
-    private static ConsoleColor GetForegroundColor(View view, int lineIndex)
+    private static ConsoleColor? GetForegroundColor(View view, int lineIndex)
     {
         var changes = GetChanges(view, lineIndex);
         if (changes is null)
-            return ConsoleColor.Gray;
+            return null;
 
         switch (changes.Status)
         {
@@ -34,11 +34,11 @@ internal sealed class FileDocumentLineRenderer : ViewLineRenderer
             case ChangeKind.TypeChanged:
             case ChangeKind.Unreadable:
             default:
-                return ConsoleColor.Gray;
+                return null;
         }
     }
 
-    private static ConsoleColor GetBackgroundColor(View view, int lineIndex)
+    private static ConsoleColor? GetBackgroundColor(View view, int lineIndex)
     {
         var foregroundColor = GetForegroundColor(view, lineIndex);
 
@@ -50,7 +50,7 @@ internal sealed class FileDocumentLineRenderer : ViewLineRenderer
                 : ConsoleColor.DarkGray;
         }
 
-        return ConsoleColor.Black;
+        return null;
     }
 
     public override void Render(View view, int lineIndex)

--- a/src/git-istage/UI/Label.cs
+++ b/src/git-istage/UI/Label.cs
@@ -6,8 +6,8 @@ internal sealed class Label
     private readonly int _left;
     private readonly int _width;
 
-    private ConsoleColor _foreground = ConsoleColor.Gray;
-    private ConsoleColor _background = ConsoleColor.Black;
+    private ConsoleColor? _foreground = null;
+    private ConsoleColor? _background = null;
     private string _text = string.Empty;
 
     public Label(int top, int left, int right)
@@ -17,7 +17,7 @@ internal sealed class Label
         _width = right - left;
     }
 
-    public ConsoleColor Foreground
+    public ConsoleColor? Foreground
     {
         get => _foreground;
         set
@@ -27,7 +27,7 @@ internal sealed class Label
         }
     }
 
-    public ConsoleColor Background
+    public ConsoleColor? Background
     {
         get => _background;
         set

--- a/src/git-istage/UI/View.cs
+++ b/src/git-istage/UI/View.cs
@@ -159,7 +159,7 @@ internal sealed class View
     {
         Vt100.SetCursorPosition(0, visualLine);
         Vt100.SetForegroundColor(ConsoleColor.DarkGray);
-        Vt100.SetBackgroundColor(ConsoleColor.Black);
+        Vt100.SetBackgroundColor();
         Console.Write("~");
         Vt100.EraseRestOfCurrentLine();
     }
@@ -209,6 +209,7 @@ internal sealed class View
             {
                 // We need to scroll up by -delta lines.
 
+                Vt100.SetBackgroundColor();
                 Vt100.ScrollDown(Math.Abs(delta));
 
                 for (var i = 0; i < -delta; i++)
@@ -223,6 +224,7 @@ internal sealed class View
 
                 var visualLineCount = Height - delta;
 
+                Vt100.SetBackgroundColor();
                 Vt100.ScrollUp(delta);
 
                 for (var i = 0; i < delta; i++)

--- a/src/git-istage/UI/ViewLineRenderer.cs
+++ b/src/git-istage/UI/ViewLineRenderer.cs
@@ -8,12 +8,12 @@ internal class ViewLineRenderer
     {
         var line = view.Document.GetLine(lineIndex);
         var isSelected = view.SelectedLine == lineIndex;
-        var foregroundColor = ConsoleColor.Gray;
-        var backgroundColor = isSelected ? ConsoleColor.DarkGray : ConsoleColor.Black;
+        ConsoleColor? foregroundColor = null;
+        ConsoleColor? backgroundColor = isSelected ? ConsoleColor.DarkGray : null;
         RenderLine(view, lineIndex, line, foregroundColor, backgroundColor);
     }
 
-    protected static void RenderLine(View view, int lineIndex, string line, ConsoleColor foregroundColor, ConsoleColor backgroundColor)
+    protected static void RenderLine(View view, int lineIndex, string line, ConsoleColor? foregroundColor, ConsoleColor? backgroundColor)
     {
         var textStart = Math.Min(view.LeftChar, line.Length);
         var textLength = Math.Max(Math.Min(view.Width, line.Length - view.LeftChar), 0);

--- a/src/git-istage/UI/Vt100.cs
+++ b/src/git-istage/UI/Vt100.cs
@@ -37,48 +37,58 @@ internal static class Vt100
         Console.Write("\x1b[27m");
     }
 
-    public static void SetForegroundColor(int r, int g, int b)
+    public static void SetForegroundColor(ConsoleColor? color = null)
     {
-        Console.Write($"\x1b[38;2;{r};{g};{b}m");
+        // If color is null, set to default
+        var code = color != null ? GetColor(color.Value, foreground: true) : 39;
+        Console.Write($"\x1b[{(int)code}m");
     }
 
-    public static void SetBackgroundColor(int r, int g, int b)
+    public static void SetBackgroundColor(ConsoleColor? color = null)
     {
-        Console.Write($"\x1b[48;2;{r};{g};{b}m");
+        // If color is null, set to default
+        var code = color != null ? GetColor(color.Value, foreground: false) : 49;
+        Console.Write($"\x1b[{(int)code}m");
     }
 
-    public static void SetForegroundColor(ConsoleColor color)
-    {
-        var (r, g, b) = GetColor(color);
-        SetForegroundColor(r, g, b);
-    }
-
-    public static void SetBackgroundColor(ConsoleColor color)
-    {
-        var (r, g, b) = GetColor(color);
-        SetBackgroundColor(r, g, b);
-    }
-
-    private static (int R, int G, int B) GetColor(ConsoleColor color)
+    private static int GetColor(ConsoleColor color, bool foreground)
     {
         switch (color)
         {
-            case ConsoleColor.Black: return (12, 12, 12);
-            case ConsoleColor.DarkBlue: return (0, 55, 218);
-            case ConsoleColor.DarkGreen: return (19, 161, 14);
-            case ConsoleColor.DarkCyan: return (58, 150, 221);
-            case ConsoleColor.DarkRed: return (197, 15, 31);
-            case ConsoleColor.DarkMagenta: return (136, 23, 152);
-            case ConsoleColor.DarkYellow: return (193, 156, 0);
-            case ConsoleColor.Gray: return (204, 204, 204);
-            case ConsoleColor.DarkGray: return (118, 118, 118);
-            case ConsoleColor.Blue: return (59, 120, 255);
-            case ConsoleColor.Green: return (22, 198, 12);
-            case ConsoleColor.Cyan: return (97, 214, 214);
-            case ConsoleColor.Red: return (231, 72, 86);
-            case ConsoleColor.Magenta: return (180, 0, 158);
-            case ConsoleColor.Yellow: return (249, 241, 165);
-            case ConsoleColor.White: return (242, 242, 242);
+            case ConsoleColor.Black when foreground: return 30;
+            case ConsoleColor.DarkBlue when foreground: return 34;
+            case ConsoleColor.DarkGreen when foreground: return 32;
+            case ConsoleColor.DarkCyan when foreground: return 36;
+            case ConsoleColor.DarkRed when foreground: return 31;
+            case ConsoleColor.DarkMagenta when foreground: return 35;
+            case ConsoleColor.DarkYellow when foreground: return 33;
+            case ConsoleColor.Gray when foreground: return 37;
+            case ConsoleColor.DarkGray when foreground: return 90;
+            case ConsoleColor.Blue when foreground: return 94;
+            case ConsoleColor.Green when foreground: return 92;
+            case ConsoleColor.Cyan when foreground: return 96;
+            case ConsoleColor.Red when foreground: return 91;
+            case ConsoleColor.Magenta when foreground: return 95;
+            case ConsoleColor.Yellow when foreground: return 93;
+            case ConsoleColor.White when foreground: return 97;
+
+            case ConsoleColor.Black when !foreground: return 40;
+            case ConsoleColor.DarkBlue when !foreground: return 44;
+            case ConsoleColor.DarkGreen when !foreground: return 42;
+            case ConsoleColor.DarkCyan when !foreground: return 46;
+            case ConsoleColor.DarkRed when !foreground: return 41;
+            case ConsoleColor.DarkMagenta when !foreground: return 45;
+            case ConsoleColor.DarkYellow when !foreground: return 43;
+            case ConsoleColor.Gray when !foreground: return 47;
+            case ConsoleColor.DarkGray when !foreground: return 100;
+            case ConsoleColor.Blue when !foreground: return 104;
+            case ConsoleColor.Green when !foreground: return 102;
+            case ConsoleColor.Cyan when !foreground: return 106;
+            case ConsoleColor.Red when !foreground: return 101;
+            case ConsoleColor.Magenta when !foreground: return 105;
+            case ConsoleColor.Yellow when !foreground: return 103;
+            case ConsoleColor.White when !foreground: return 107;
+
             default:
                 throw new Exception($"Unexpected color: {color}");
         }


### PR DESCRIPTION
Color schemes like PowerShell and Vintage have background and foreground colors that are different from ConsoleColor.Black and ConsoleColor.Gray colors, respectively. Code assuming these colors match the palette results in the wrong color being used during rendering. For navigation (especially when scrolling up or down) this can cause tearing as the correct background is used to clear the screen, then the incorrect color from the palette is used to render the line.

This change uses nullable ConsoleColor throughout the view and line renderers, where null implies reset the background or foreground color, and an explicit ConsoleColor.Black or ConsoleColor.Gray is used to use that color palette index. Also switched the Vt100 code to use the color palette index instead of the hard-coded RGB values. Full theme customization as described in #50 is a much larger change, and supporting the users color palette in that system would still be desirable. The added benefit is that if the color palette changes the app doesn't need to be restarted to pick up the change.

Before:
![image](https://user-images.githubusercontent.com/20784649/227744099-2efa6ae0-d565-42f7-b69e-b1a09615cd27.png)

After:
![image](https://user-images.githubusercontent.com/20784649/227744048-5796faf6-f96a-4d7c-b2eb-05565a0e9b7d.png)