### PR TITLE
Update LibGit2Sharp package to 0.27.2

### DIFF
--- a/src/git-istage/git-istage.csproj
+++ b/src/git-istage/git-istage.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Includes the latest libgit2 release which fixes a few loading issues on Ubuntu and other platforms. Should address most issues reported in #40.

Confirmed from Codespace running Focal Fossa:
```shell
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
```